### PR TITLE
Hydrator preheating

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -38,7 +38,9 @@ class Factory
 
     protected static function preheat(Hydrator $hydrator, array $options)
     {
-        if (!isset($options[Options::NAMESPACE_DIR]) || !isset($options[Options::NAMESPACE])) {
+        $hasNamespaceDir = !isset($options[Options::NAMESPACE_DIR]);
+        $hasNamespace = !isset($options[Options::NAMESPACE]);
+        if ($hasNamespaceDir || $hasNamespace) {
             return;
         }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -16,7 +16,11 @@ class Factory
     {
         $options[Options::ANNOTATIONS] = static::annotations($options[Options::ANNOTATIONS] ?? []);
 
-        return new Hydrator($options);
+        $hydrator = new Hydrator($options);
+
+        self::preheat($hydrator, $options);
+
+        return $hydrator;
     }
 
     protected static function annotations(array $annotations): array
@@ -30,5 +34,14 @@ class Factory
         }
 
         return $annotations;
+    }
+
+    protected static function preheat(Hydrator $hydrator, array $options)
+    {
+        if (!isset($options[Options::NAMESPACE_DIR]) || !isset($options[Options::NAMESPACE])) {
+            return;
+        }
+
+        $hydrator->preheat($options[Options::NAMESPACE_DIR], $options[Options::NAMESPACE]);
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -38,9 +38,9 @@ class Factory
 
     protected static function preheat(Hydrator $hydrator, array $options)
     {
-        $hasNamespaceDir = !isset($options[Options::NAMESPACE_DIR]);
-        $hasNamespace = !isset($options[Options::NAMESPACE]);
-        if ($hasNamespaceDir || $hasNamespace) {
+        $hasNamespaceDir = isset($options[Options::NAMESPACE_DIR]);
+        $hasNamespace = isset($options[Options::NAMESPACE]);
+        if (!$hasNamespaceDir || !$hasNamespace) {
             return;
         }
 

--- a/src/Hydrator.php
+++ b/src/Hydrator.php
@@ -77,6 +77,11 @@ class Hydrator
         $this->options[Options::EXTRA_PROPERTIES]['hydrator'] = $this;
     }
 
+    public function preheat()
+    {
+        // TODO
+    }
+
     /**
      * @param string $class
      * @param array $json

--- a/src/Options.php
+++ b/src/Options.php
@@ -5,6 +5,7 @@ namespace ApiClients\Foundation\Hydrator;
 class Options
 {
     const NAMESPACE =          'namespace';
+    const NAMESPACE_DIR =      'namespace_dir';
     const NAMESPACE_SUFFIX =   'namespace_suffix';
     const RESOURCE_CACHE_DIR = 'resource_cache_dir';
     const ANNOTATION_CACHE =   'annotation_cache';

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -125,4 +125,27 @@ class HydratorTest extends TestCase
         );
         $this->assertFalse($classCount === count(get_declared_classes()));
     }
+
+    public function testPreheatFactory()
+    {
+        $tmpDir = $this->getTmpDir();
+        Factory::create([
+            Options::NAMESPACE => 'ApiClients\Tests\Foundation\Hydrator\Resources',
+            Options::NAMESPACE_SUFFIX => 'Async',
+            Options::RESOURCE_CACHE_DIR => $tmpDir,
+            Options::RESOURCE_NAMESPACE => $this->getRandomNameSpace(),
+        ]);
+
+        $classCount = count(get_declared_classes());
+
+        Factory::create([
+            Options::NAMESPACE => 'ApiClients\Tests\Foundation\Hydrator\Resources',
+            Options::NAMESPACE_DIR => __DIR__ . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR,
+            Options::NAMESPACE_SUFFIX => 'Async',
+            Options::RESOURCE_CACHE_DIR => $tmpDir,
+            Options::RESOURCE_NAMESPACE => $this->getRandomNameSpace(),
+        ]);
+
+        $this->assertFalse($classCount === count(get_declared_classes()));
+    }
 }

--- a/tests/HydratorTest.php
+++ b/tests/HydratorTest.php
@@ -107,4 +107,22 @@ class HydratorTest extends TestCase
         $files = $this->getFilesInDirectory($annotationCache);
         $this->assertSame(4, count($files));
     }
+
+    public function testPreheat()
+    {
+        $tmpDir = $this->getTmpDir();
+        $hydrator = Factory::create([
+            Options::NAMESPACE => 'ApiClients\Tests\Foundation\Hydrator\Resources',
+            Options::NAMESPACE_SUFFIX => 'Async',
+            Options::RESOURCE_CACHE_DIR => $tmpDir,
+            Options::RESOURCE_NAMESPACE => $this->getRandomNameSpace(),
+        ]);
+
+        $classCount = count(get_declared_classes());
+        $hydrator->preheat(
+            __DIR__ . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR,
+            'ApiClients\Tests\Foundation\Hydrator\Resources'
+        );
+        $this->assertFalse($classCount === count(get_declared_classes()));
+    }
 }


### PR DESCRIPTION
When a cache is passed for annotations small bits of this code block when parsing annotations and saving the results. But also when reading from existing cache. The purpose of the preheat method is to ensure all this happens in one go and preferably before the loop runs so everything is ready to be used in memory.
